### PR TITLE
Cars#show improvements

### DIFF
--- a/app/controllers/chargings_controller.rb
+++ b/app/controllers/chargings_controller.rb
@@ -17,7 +17,7 @@ class ChargingsController < ApplicationController
         # Send params &update=chargings to views/cars/show.turbo_stream
         # to update the Chargings Table and its Pagination (request is processed as Turbo_Stream)
         format.html { 
-          redirect_to car_url(@car, params: { update: "chargings" }), 
+          redirect_to car_url(@car, params: { update: "chargings", clear: "form" }), 
           status: :see_other, 
           notice: "Charging was successfully created."
         }

--- a/app/controllers/repairs_controller.rb
+++ b/app/controllers/repairs_controller.rb
@@ -13,7 +13,7 @@ class RepairsController < ApplicationController
     respond_to do |format|             
       if @repair.save
         format.html { 
-          redirect_to car_url(@car, params: { update: "repairs" }), 
+          redirect_to car_url(@car, params: { update: "repairs", clear: "form" }), 
           status: :see_other, 
           notice: "Repair was successfully created." 
         }

--- a/app/controllers/taxes_controller.rb
+++ b/app/controllers/taxes_controller.rb
@@ -15,7 +15,7 @@ class TaxesController < ApplicationController
     respond_to do |format|
       if @tax.save
         format.html { 
-          redirect_to car_url(@car, params: { update: "taxes" }), 
+          redirect_to car_url(@car, params: { update: "taxes", clear: "form" }), 
           status: :see_other, 
           notice: "Tax was successfully added."
         }

--- a/app/views/cars/show.html.slim
+++ b/app/views/cars/show.html.slim
@@ -2,11 +2,11 @@ div[class="navbar-cars-show"]
   nav
     = link_to t("car.back") , cars_path, class: "button-add"
 
-    = link_to t('car.charg'), "", class: "button-add form_button", id: "chargingForm"
+    = link_to t('car.charg'), "", class: "button-add form_button", name: "chargingForm"
 
-    = link_to t('car.repair'), "", class: "button-add form_button", id: "repairForm"
+    = link_to t('car.repair'), "", class: "button-add form_button", name: "repairForm"
 
-    = link_to t('car.at'), "", class: "button-add form_button", id: "taxForm"
+    = link_to t('car.at'), "", class: "button-add form_button", name: "taxForm"
 
 br
 section.vh-100

--- a/app/views/chargings/_paginate.html.slim
+++ b/app/views/chargings/_paginate.html.slim
@@ -1,2 +1,2 @@
 == paginate chargings, param_name: :chargings_page, data: { turbo_stream: true }, \
-    params: {update: "chargings"}
+    params: { update: "chargings", clear: nil }

--- a/app/views/chargings/_update.turbo_stream.slim
+++ b/app/views/chargings/_update.turbo_stream.slim
@@ -2,3 +2,7 @@
   == render chargings
 == turbo_stream.update "chargingsPagination"
   == render "chargings/paginate", chargings: chargings
+  
+- if params["clear"] == "form"
+  == turbo_stream.update "chargingForm"
+    == render 'chargings/form', car: @car, charging: @car.chargings.build

--- a/app/views/repairs/_paginate.html.slim
+++ b/app/views/repairs/_paginate.html.slim
@@ -1,2 +1,2 @@
 == paginate repairs, param_name:  :repairs_page, data: { turbo_stream: true }, \
-    params: { update: "repairs" }
+    params: { update: "repairs", clear: nil }

--- a/app/views/repairs/_update.turbo_stream.slim
+++ b/app/views/repairs/_update.turbo_stream.slim
@@ -1,4 +1,8 @@
-  == turbo_stream.update "repairsList"
-    == render repairs
-  == turbo_stream.update "repairsPagination"
-    == render "repairs/paginate", repairs: repairs
+== turbo_stream.update "repairsList"
+  == render repairs
+== turbo_stream.update "repairsPagination"
+  == render "repairs/paginate", repairs: repairs
+
+- if params["clear"] == "form"
+  == turbo_stream.update "repairForm"
+    == render 'repairs/form', car: @car, repair: @car.repairs.build

--- a/app/views/tax_mailer/tax_mailer.html.slim
+++ b/app/views/tax_mailer/tax_mailer.html.slim
@@ -17,4 +17,4 @@ body
   hr
 
   p
-    == link_to "View taxes", car_url(@due_tax.car_id)
+    == link_to "View taxes", car_url(id: @due_tax.car_id)

--- a/app/views/tax_mailer/tax_mailer.text.slim
+++ b/app/views/tax_mailer/tax_mailer.text.slim
@@ -12,4 +12,4 @@
 
 |
    You can visit the following URL to view your taxes: 
-== car_url(@due_tax.car_id)
+== car_url(id: @due_tax.car_id)

--- a/app/views/taxes/_paginate.html.slim
+++ b/app/views/taxes/_paginate.html.slim
@@ -1,2 +1,2 @@
 == paginate taxes, param_name:  :taxes_page, data: { turbo_stream: true }, \
-    params: { update: "taxes" }
+    params: { update: "taxes", clear: nil }

--- a/app/views/taxes/_update.turbo_stream.slim
+++ b/app/views/taxes/_update.turbo_stream.slim
@@ -1,4 +1,8 @@
-  == turbo_stream.update "taxesList"
-    == render taxes
-  == turbo_stream.update "taxesPagination"
-    == render "taxes/paginate", taxes: taxes
+== turbo_stream.update "taxesList"
+  == render taxes
+== turbo_stream.update "taxesPagination"
+  == render "taxes/paginate", taxes: taxes
+
+- if params["clear"] == "form"
+  == turbo_stream.update "taxForm"
+    == render 'taxes/form', car: @car, tax: @car.taxes.build

--- a/config/locales/en/car.yml
+++ b/config/locales/en/car.yml
@@ -15,7 +15,7 @@ en:
     repair: "Add repair"
     others: "Taxes and others"
     edit: "Edit your car"
-    edit_discr: "Edit "
+    edit_descr: "Edit "
     invoice: " Invoice "
     del: "Delete"
     station: "Station "

--- a/public/javascripts/lib/carsShowPage.js
+++ b/public/javascripts/lib/carsShowPage.js
@@ -29,14 +29,15 @@ tableHeadingsArr.forEach(heading => {
 formButtonsArr.forEach(button => {
     button.addEventListener("click", (event) => {
         event.preventDefault();
-        let buttonId = button.id;
-        let targetedFormContainer = document.querySelector(`div[id="${buttonId}"]`);
+        let buttonName = button.name;
+        let targetedFormContainer = document.querySelector(`div[id="${buttonName}"]`);
 
         if (targetedFormContainer.classList.contains("collapse")) {
             let formContainersArr = [...document.getElementsByClassName('formContainer')];
             formContainersArr.forEach(formContainer => {
-                if (formContainer.id == targetedFormContainer.id) { return };
-                if (formContainer.classList.contains("collapse")) { return };
+                if (formContainer.id == targetedFormContainer.id || 
+                    formContainer.classList.contains("collapse")) { return };
+                    
                 formContainer.classList.add("collapse");
             });
 


### PR DESCRIPTION
Clear the forms on cars#show on Create, give names to the buttons for showing the forms instead of IDs, because of id duplicates.
In carsShowPage.js get the button.name instead of button.id to target the corresponding Form